### PR TITLE
Audit `unsafe` usage

### DIFF
--- a/pest/src/iterators/pair.rs
+++ b/pest/src/iterators/pair.rs
@@ -34,14 +34,11 @@ pub struct Pair<'i, R> {
     /// All `QueueableToken`s' `input_pos` must be valid character boundary indices into `input`.
     queue: Rc<Vec<QueueableToken<R>>>,
     input: &'i str,
-    /// # Safety
-    ///
-    /// Must be a valid character boundary in `input`; that is: `input[start..]` must not panic.
+    /// Token index into `queue`.
     start: usize
 }
 
 // TODO(safety): QueueableTokens must be valid indices into input.
-// TODO(safety): start must be a valid index into input.
 pub fn new<R: RuleType>(queue: Rc<Vec<QueueableToken<R>>>, input: &str, start: usize) -> Pair<R> {
     if cfg!(debug_assertions) {
         for tok in queue.iter() {
@@ -50,7 +47,6 @@ pub fn new<R: RuleType>(queue: Rc<Vec<QueueableToken<R>>>, input: &str, start: u
                     assert!(input.get(input_pos..).is_some(), "💥 UNSAFE `Pair` CREATED 💥")
             }
         }
-        assert!(input.get(start..).is_some(), "💥 UNSAFE `Pair` CREATED 💥")
     }
 
     Pair {

--- a/pest/src/iterators/pair.rs
+++ b/pest/src/iterators/pair.rs
@@ -44,8 +44,8 @@ pub struct Pair<'i, R> {
 // TODO(safety): start must be a valid index into input.
 pub fn new<R: RuleType>(queue: Rc<Vec<QueueableToken<R>>>, input: &str, start: usize) -> Pair<R> {
     if cfg!(debug_assertions) {
-        for tok in queue {
-            match tok {
+        for tok in queue.iter() {
+            match *tok {
                 QueueableToken::Start { input_pos, .. } | QueueableToken::End { input_pos, .. } =>
                     assert!(input.get(input_pos..).is_some(), "💥 UNSAFE `Pair` CREATED 💥")
             }

--- a/pest/src/iterators/pair.rs
+++ b/pest/src/iterators/pair.rs
@@ -29,12 +29,30 @@ use span::{self, Span};
 /// [`Token`]: ../enum.Token.html
 #[derive(Clone)]
 pub struct Pair<'i, R> {
+    /// # Safety
+    ///
+    /// All `QueueableToken`s' `input_pos` must be valid character boundary indices into `input`.
     queue: Rc<Vec<QueueableToken<R>>>,
     input: &'i str,
+    /// # Safety
+    ///
+    /// Must be a valid character boundary in `input`; that is: `input[start..]` must not panic.
     start: usize
 }
 
+// TODO(safety): QueueableTokens must be valid indices into input.
+// TODO(safety): start must be a valid index into input.
 pub fn new<R: RuleType>(queue: Rc<Vec<QueueableToken<R>>>, input: &str, start: usize) -> Pair<R> {
+    if cfg!(debug_assertions) {
+        for tok in queue {
+            match tok {
+                QueueableToken::Start { input_pos, .. } | QueueableToken::End { input_pos, .. } =>
+                    assert!(input.get(input_pos..).is_some(), "💥 UNSAFE `Pair` CREATED 💥")
+            }
+        }
+        assert!(input.get(start..).is_some(), "💥 UNSAFE `Pair` CREATED 💥")
+    }
+
     Pair {
         queue,
         input,

--- a/pest/src/iterators/tokens.rs
+++ b/pest/src/iterators/tokens.rs
@@ -23,18 +23,31 @@ use token::Token;
 /// [`Pairs::tokens`]: struct.Pairs.html#method.tokens
 #[derive(Clone)]
 pub struct Tokens<'i, R> {
+    /// # Safety:
+    ///
+    /// All `QueueableToken`s' `input_pos` must be valid character boundary indices into `input`.
     queue: Rc<Vec<QueueableToken<R>>>,
     input: &'i str,
     start: usize,
     end: usize
 }
 
+// TODO(safety): QueueableTokens must be valid indices into input.
 pub fn new<R: RuleType>(
     queue: Rc<Vec<QueueableToken<R>>>,
     input: &str,
     start: usize,
     end: usize
 ) -> Tokens<R> {
+    if cfg!(debug_assertions) {
+        for tok in queue {
+            match tok {
+                QueueableToken::Start { input_pos, .. } | QueueableToken::End { input_pos, .. } =>
+                    assert!(input.get(input_pos..).is_some(), "💥 UNSAFE `Tokens` CREATED 💥")
+            }
+        }
+    }
+
     Tokens {
         queue,
         input,

--- a/pest/src/iterators/tokens.rs
+++ b/pest/src/iterators/tokens.rs
@@ -40,8 +40,8 @@ pub fn new<R: RuleType>(
     end: usize
 ) -> Tokens<R> {
     if cfg!(debug_assertions) {
-        for tok in queue {
-            match tok {
+        for tok in queue.iter() {
+            match *tok {
                 QueueableToken::Start { input_pos, .. } | QueueableToken::End { input_pos, .. } =>
                     assert!(input.get(input_pos..).is_some(), "💥 UNSAFE `Tokens` CREATED 💥")
             }

--- a/pest/src/parser_state.rs
+++ b/pest/src/parser_state.rs
@@ -86,8 +86,8 @@ where
                     positives: state.pos_attempts.clone(),
                     negatives: state.neg_attempts.clone()
                 },
-                // TODO: Figure out why state.attempt_pos is a valid position?
-                unsafe { position::Position::new_unchecked(input, state.attempt_pos) }
+                // TODO(performance): Guarantee state.attempt_pos is a valid position
+                position::Position::new(input, state.attempt_pos).unwrap()
             ))
         }
     }

--- a/pest/src/position.rs
+++ b/pest/src/position.rs
@@ -20,11 +20,18 @@ use span;
 #[derive(Clone)]
 pub struct Position<'i> {
     input: &'i str,
+    /// # Safety:
+    ///
+    /// `input[pos..]` must be a valid codepoint boundary (should not panic when indexing thus).
     pos: usize
 }
 
 impl<'i> Position<'i> {
-
+    /// Create a new `Position` without checking invariants. (Checked with `debug_assertions`.)
+    ///
+    /// # Safety:
+    ///
+    /// `input[pos..]` must be a valid codepoint boundary (should not panic when indexing thus).
     pub(crate) unsafe fn new_unchecked(input: &str, pos: usize) -> Position {
         debug_assert!(input.get(pos..).is_some());
         Position { input, pos }

--- a/pest/src/span.rs
+++ b/pest/src/span.rs
@@ -21,12 +21,22 @@ use position;
 #[derive(Clone)]
 pub struct Span<'i> {
     input: &'i str,
+    /// # Safety
+    ///
+    /// Must be a valid character boundary index into `input`.
     start: usize,
+    /// # Safety
+    ///
+    /// Must be a valid character boundary index into `input`.
     end: usize
 }
 
 impl<'i> Span<'i> {
-
+    /// Create a new `Span` without checking invariants. (Checked with `debug_assertions`.)
+    ///
+    /// # Safety
+    ///
+    /// `input[start..end]` must be a valid subslice; that is, said indexing should not panic.
     pub(crate) unsafe fn new_unchecked(input: &str, start: usize, end: usize) -> Span {
         debug_assert!(input.get(start..end).is_some());
         Span { input, start, end }


### PR DESCRIPTION
I didn't touch any fn interfaces, just recorded exactly what assumptions were made in `unsafe` blocks.

Thankfully, I think both of the `new` fn that I've put `// TODO(safety)` on are not exported, so we should be good to mark them as having the unsafe requirements.

I count a total of 10 uses of `unsafe` currently in this branch:

- `unsafe fn Span::new_unchecked`
- `unsafe fn Position::new_unchecked`
- 2x `unsafe { Tokens into Position }`
- 1x `unsafe { Pair into Span }`
- 4x `unsafe { Span into Position }`
- 1x `unsafe { (Position, Position) into Span }`

Other than the safety guarantee that all `QueueableTokens` for a `Tokens` are valid indices (needs further investigation and probably to mark more internal fn `unsafe`), all of these seem justified.

cc @dragostis, pest-parser#303